### PR TITLE
#150: Fix IntoValues pointer usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub struct Values<'a, V> {
 /// Into-iterator over the values of a [`Map`].
 pub struct IntoValues<V> {
     current: NodeId,
-    head: *mut Node<V>,
+    head: *const Node<V>,
 }
 
 /// Iterator over the keys of a [`Map`].


### PR DESCRIPTION
## Summary
- update `IntoValues::next` to clone from shared node references instead of creating mutable aliases
- store the iterator head as a `*const Node` and cast with `cast_const` to document the read-only access

## Testing
- cargo +nightly fmt --
- cargo build --all-targets
- cargo clippy -- -D warnings
- cargo test --all
- cargo audit
- cargo deny check *(fails: unable to fetch advisory database due to network error)*