### PR TITLE
#150: Remove unmaintained paste dev dependency and add cargo-deny config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ dependencies = [
  "bincode",
  "criterion",
  "intmap",
- "paste",
  "serde",
 ]
 
@@ -273,12 +272,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ bincode = { version = "2", features = ["serde"], optional = true }
 
 criterion = { version = "0.7", features = ["html_reports"], optional = true }
 
-[dev-dependencies]
-paste = "1.0"
-
 [features]
 default = []
 serde = ["dep:serde", "dep:bincode"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = ["MIT"]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
## Summary
- drop the unmaintained `paste` dev-dependency from the manifest and lockfile
- add a minimal `deny.toml` so cargo-deny can run with the crate's MIT license policy

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check --disable-fetch
