### PR TITLE
Format code with nightly rustfmt

### DIFF
--- a/benches/compare_with_intmap.rs
+++ b/benches/compare_with_intmap.rs
@@ -89,27 +89,35 @@ fn compare_ctors_prefill(c: &mut Criterion) {
     for &size in SIZES {
         group.throughput(Throughput::Elements(size as u64));
 
-        group.bench_with_input(BenchmarkId::new("intmap_ctor+fill", size), &size, |b, &n| {
-            b.iter(|| {
-                let mut m = IntMapI32::with_capacity(n);
-                let v = black_box(42_i32);
-                for i in 0..n {
-                    m.insert(i, v);
-                }
-                black_box(m);
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("intmap_ctor+fill", size),
+            &size,
+            |b, &n| {
+                b.iter(|| {
+                    let mut m = IntMapI32::with_capacity(n);
+                    let v = black_box(42_i32);
+                    for i in 0..n {
+                        m.insert(i, v);
+                    }
+                    black_box(m);
+                });
+            },
+        );
 
-        group.bench_with_input(BenchmarkId::new("emap_ctor+fill_safe", size), &size, |b, &n| {
-            b.iter(|| {
-                let mut m = EMap::<i32>::with_capacity_none(n);
-                let v = black_box(42_i32);
-                for i in 0..n {
-                    m.insert(i, v);
-                }
-                black_box(m);
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("emap_ctor+fill_safe", size),
+            &size,
+            |b, &n| {
+                b.iter(|| {
+                    let mut m = EMap::<i32>::with_capacity_none(n);
+                    let v = black_box(42_i32);
+                    for i in 0..n {
+                        m.insert(i, v);
+                    }
+                    black_box(m);
+                });
+            },
+        );
 
         group.bench_with_input(
             BenchmarkId::new("emap_ctor+fill_unchecked", size),
@@ -220,21 +228,25 @@ fn compare_values(c: &mut Criterion) {
             );
         });
 
-        group.bench_with_input(BenchmarkId::new("emap_values_unchecked", size), &size, |b, &n| {
-            b.iter_batched(
-                || setup_emap_prefilled_unchecked(n, 42),
-                |m| {
-                    let mut acc = 0i64;
-                    for _ in 0..PASSES {
-                        for v in m.values() {
-                            acc += black_box(*v as i64);
+        group.bench_with_input(
+            BenchmarkId::new("emap_values_unchecked", size),
+            &size,
+            |b, &n| {
+                b.iter_batched(
+                    || setup_emap_prefilled_unchecked(n, 42),
+                    |m| {
+                        let mut acc = 0i64;
+                        for _ in 0..PASSES {
+                            for v in m.values() {
+                                acc += black_box(*v as i64);
+                            }
                         }
-                    }
-                    black_box(acc);
-                },
-                BatchSize::SmallInput,
-            );
-        });
+                        black_box(acc);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
     }
     group.finish();
 }

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -50,7 +50,9 @@ struct Foo {
 #[test]
 #[ignore]
 fn clone_of_wrapper() {
-    let mut f: Foo = Foo { m: Map::with_capacity_none(16) };
+    let mut f: Foo = Foo {
+        m: Map::with_capacity_none(16),
+    };
     f.m.insert(7, 42);
     assert_eq!(1, f.clone().m.len());
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -121,7 +121,10 @@ impl<V: Clone> Map<V> {
     #[inline]
     pub fn init_with_some(&mut self, cap: usize, v: V) {
         let capacity = self.capacity();
-        assert!(cap <= capacity, "initialization bound {cap} exceeds capacity {capacity}",);
+        assert!(
+            cap <= capacity,
+            "initialization bound {cap} exceeds capacity {capacity}",
+        );
         let mut previous_used = NodeId::new(NodeId::UNDEF);
         self.first_free = NodeId::new(NodeId::UNDEF);
         self.first_used = NodeId::new(NodeId::UNDEF);
@@ -358,7 +361,11 @@ mod tests {
     impl PanicOnClone {
         fn new(panic_after: usize, clones: Rc<Cell<usize>>, active: Rc<Cell<usize>>) -> Self {
             active.set(active.get() + 1);
-            Self { clones, active, panic_after }
+            Self {
+                clones,
+                active,
+                panic_after,
+            }
         }
     }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -91,7 +91,11 @@ impl<V> Map<V> {
     pub const fn iter(&self) -> Iter<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't iter() non-initialized Map");
-        Iter { current: self.first_used, head: self.head, _marker: PhantomData }
+        Iter {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
     /// Make a mutable iterator over all items.
     ///
@@ -117,7 +121,11 @@ impl<V> Map<V> {
     pub fn iter_mut(&mut self) -> IterMut<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't iter_mut() non-initialized Map");
-        IterMut { current: self.first_used, head: self.head, _marker: PhantomData }
+        IterMut {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 
     /// Make an iterator over all items.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -30,7 +30,10 @@ impl<V> Map<V> {
     pub const fn keys(&self) -> Keys<V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't keys() non-initialized Map");
-        Keys { current: self.first_used, head: self.head }
+        Keys {
+            current: self.first_used,
+            head: self.head,
+        }
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -279,14 +279,22 @@ impl<V> Map<V> {
     #[allow(unused_variables)]
     fn assert_boundaries_debug(&self, k: usize) {
         #[cfg(debug_assertions)]
-        assert!(k < self.capacity(), "The key {k} is over the boundary {}", self.capacity());
+        assert!(
+            k < self.capacity(),
+            "The key {k} is over the boundary {}",
+            self.capacity()
+        );
     }
 
     /// Check the boundary condition.
     #[inline]
     #[allow(unused_variables)]
     fn assert_boundaries(&self, k: usize) {
-        assert!(k < self.capacity(), "The key {k} is over the boundary {}", self.capacity());
+        assert!(
+            k < self.capacity(),
+            "The key {k} is over the boundary {}",
+            self.capacity()
+        );
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -45,7 +45,11 @@ impl<V> Node<V> {
     #[inline]
     #[must_use]
     pub const fn new(next: usize, prev: usize, value: Option<V>) -> Self {
-        Self { next: NodeId::new(next), prev: NodeId::new(prev), value }
+        Self {
+            next: NodeId::new(next),
+            prev: NodeId::new(prev),
+            value,
+        }
     }
 
     #[inline]

--- a/src/values.rs
+++ b/src/values.rs
@@ -45,7 +45,11 @@ impl<V> Map<V> {
     pub const fn values(&self) -> Values<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't values() non-initialized Map");
-        Values { current: self.first_used, head: self.head, _marker: PhantomData }
+        Values {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 
     /// Make an into-iterator over all items.
@@ -58,7 +62,10 @@ impl<V> Map<V> {
     pub const fn into_values(&self) -> IntoValues<V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't into_values() non-initialized Map");
-        IntoValues { current: self.first_used, head: self.head.cast_const() }
+        IntoValues {
+            current: self.first_used,
+            head: self.head.cast_const(),
+        }
     }
 }
 

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -24,8 +24,12 @@ macro_rules! compare {
     ($title:expr, $ret:expr, $total:expr, $eI:expr, $eM:expr) => {{
         $ret.push((
             $title,
-            measure!($total, { $eI(std::hint::black_box(&mut IntMap::with_capacity(CAP))) }),
-            measure!($total, { $eM(std::hint::black_box(&mut Map::with_capacity_none(CAP))) }),
+            measure!($total, {
+                $eI(std::hint::black_box(&mut IntMap::with_capacity(CAP)))
+            }),
+            measure!($total, {
+                $eM(std::hint::black_box(&mut Map::with_capacity_none(CAP)))
+            }),
         ));
     }};
 }


### PR DESCRIPTION
## Summary
- reflow bench closures and macro invocations using nightly rustfmt defaults
- expand struct literals for readability across iterator helpers and assertions

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check (fails: unable to fetch advisory database)


------
https://chatgpt.com/codex/tasks/task_e_68dc7b5f713c832ba9b9c655ac698b3f