### PR TITLE
#150: Add fallible push API for saturated maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ If more than 100 keys will be added to the map, it will panic.
 The map doesn't increase its size automatically, like [`Vec`][Vec] does
 (this is one of the reasons why we are faster).
 
+When you need to avoid a panic at the capacity limit, use [`Map::try_push`]
+which reports the problem as an error:
+
+```rust
+use emap::{Map, MapFullError};
+let mut m: Map<&str> = Map::with_capacity_none(1);
+m.try_push("foo")?;
+assert!(matches!(m.try_push("bar"), Err(MapFullError)));
+# Ok::<(), MapFullError>(())
+```
+
 Read [the API documentation](https://docs.rs/emap/latest/emap/).
 The struct [`emap::Map`][Map] is designed as closely similar to
 [`std::collections::HashMap`][HashMap] as possible.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// Error returned when an operation requires a free slot but the map is full.
+///
+/// # Examples
+///
+/// ```
+/// use emap::{Map, MapFullError};
+/// let mut map: Map<u8> = Map::with_capacity_none(1);
+/// map.insert(0, 7);
+/// assert!(matches!(map.try_push(8), Err(MapFullError)));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapFullError;
+
+impl Display for MapFullError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("map capacity is exhausted")
+    }
+}
+
+impl Error for MapFullError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 mod clone;
 mod ctors;
 mod debug;
+mod error;
 mod index;
 mod iterators;
 mod keys;
@@ -36,6 +37,7 @@ pub mod node;
 mod serialization;
 mod values;
 
+pub use crate::error::MapFullError;
 use crate::node::{Node, NodeId};
 use std::alloc::Layout;
 use std::marker::PhantomData;


### PR DESCRIPTION
## Summary
- export a reusable `MapFullError` error type to report capacity exhaustion
- add `try_next_key`/`try_push` so callers can avoid panics when the map is full and extend tests accordingly
- document the new fallible API in the README for users

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check
