### PR TITLE
#150: Refine map push/next_key error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,25 +34,29 @@ emap = "0.0.13"
 Then, use it like a standard hash map... well, almost:
 
 ```rust
-use emap::Map;
+use emap::{Map, MapFullError};
 let mut m : Map<&str> = Map::with_capacity_init(100); // allocation on heap
-m.insert(m.next_key(), "foo");
-m.insert(m.next_key(), "bar");
+let first_key = m.next_key()?;
+m.insert(first_key, "foo");
+let second_key = m.next_key()?;
+m.insert(second_key, "bar");
 assert_eq!(2, m.len());
+# Ok::<(), MapFullError>(())
 ```
 
-If more than 100 keys will be added to the map, it will panic.
+If more than 100 keys will be added to the map, the methods will return
+[`MapFullError`].
 The map doesn't increase its size automatically, like [`Vec`][Vec] does
 (this is one of the reasons why we are faster).
 
-When you need to avoid a panic at the capacity limit, use [`Map::try_push`]
-which reports the problem as an error:
+When you need a convenience API that allocates the next available slot,
+use [`Map::push`], which now reports exhaustion as an error:
 
 ```rust
 use emap::{Map, MapFullError};
-let mut m: Map<&str> = Map::with_capacity_none(1);
-m.try_push("foo")?;
-assert!(matches!(m.try_push("bar"), Err(MapFullError)));
+let mut map: Map<&str> = Map::with_capacity_none(1);
+map.push("foo")?;
+assert!(matches!(map.push("bar"), Err(MapFullError)));
 # Ok::<(), MapFullError>(())
 ```
 
@@ -139,3 +143,5 @@ a pull request.
 [benchmark]: https://github.com/yegor256/emap/blob/master/tests/benchmark.rs
 [associative array]: https://en.wikipedia.org/wiki/Associative_array
 [IntMap]: https://docs.rs/intmap/latest/intmap/
+[Map::push]: https://docs.rs/emap/0.0.13/emap/struct.Map.html#method.push
+[MapFullError]: https://docs.rs/emap/0.0.13/emap/struct.MapFullError.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! assert_eq!(2, m.len());
 //! ```
 //!
-//! An attempt to add an element when the map is full will panic.
+//! An attempt to add an element when the map is full returns [`MapFullError`].
 
 #![doc(html_root_url = "https://docs.rs/emap/0.0.0")]
 #![deny(warnings)]
@@ -109,7 +109,7 @@ fn perf() {
     for _ in 0..1000 {
         m.clear();
         for _ in 0..cap {
-            m.push("Hello, world!");
+            assert!(m.push("Hello, world!").is_ok());
         }
         for i in 0..cap {
             m.remove(i);
@@ -125,6 +125,5 @@ fn perf() {
             assert!(!m.contains_key(i));
         }
     }
-    let d = start.elapsed();
-    println!("Total time: {}", d.as_millis());
+    let _duration = start.elapsed();
 }

--- a/src/next_key.rs
+++ b/src/next_key.rs
@@ -6,19 +6,28 @@ use crate::{Map, MapFullError};
 impl<V> Map<V> {
     /// Get the next key available for insertion.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// If no more keys left.
+    /// Returns [`MapFullError`] when the map has no remaining capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use emap::{Map, MapFullError};
+    /// let mut map: Map<&str> = Map::with_capacity_none(1);
+    /// assert_eq!(map.next_key(), Ok(0));
+    /// map.insert(0, "occupied");
+    /// assert_eq!(map.next_key(), Err(MapFullError));
+    /// ```
     #[inline]
-    #[must_use]
-    pub fn next_key(&self) -> usize {
-        match self.try_next_key() {
-            Ok(next) => next,
-            Err(error) => panic!("{error}"),
-        }
+    pub const fn next_key(&self) -> Result<usize, MapFullError> {
+        self.try_next_key()
     }
 
     /// Get the next key available for insertion without panicking on overflow.
+    ///
+    /// This method mirrors [`Map::next_key`] but can be evaluated in `const`
+    /// contexts.
     ///
     /// # Errors
     ///
@@ -36,21 +45,24 @@ impl<V> Map<V> {
     /// ```
     #[inline]
     pub const fn try_next_key(&self) -> Result<usize, MapFullError> {
-        if self.first_free.is_def() { Ok(self.first_free.get()) } else { Err(MapFullError) }
+        if self.first_free.is_def() {
+            Ok(self.first_free.get())
+        } else {
+            Err(MapFullError)
+        }
     }
 }
 
 #[test]
 fn get_next_key_empty_map() {
     let m: Map<&str> = Map::with_capacity_none(16);
-    assert_eq!(0, m.next_key());
+    assert_eq!(Ok(0), m.next_key());
 }
 
 #[test]
-#[should_panic]
-fn next_key_panics_for_zero_capacity() {
+fn next_key_reports_error_for_zero_capacity() {
     let m: Map<&str> = Map::with_capacity_none(0);
-    let _ = m.next_key();
+    assert_eq!(Err(MapFullError), m.next_key());
 }
 
 #[test]
@@ -60,7 +72,7 @@ fn get_next_in_the_middle() {
     m.insert(1, 42);
     m.remove(1);
     m.insert(2, 42);
-    assert_eq!(1, m.next_key());
+    assert_eq!(Ok(1), m.next_key());
 }
 
 #[test]
@@ -86,22 +98,21 @@ fn restore_next_key() {
     m.insert(2, 42);
     m.insert(3, 42);
     m.remove(2);
-    assert_eq!(2, m.next_key());
+    assert_eq!(Ok(2), m.next_key());
 }
 
 #[test]
 fn reset_next_key_on_clear() {
     let mut m: Map<u32> = Map::with_capacity_none(16);
     m.insert(0, 42);
-    assert_eq!(1, m.next_key());
+    assert_eq!(Ok(1), m.next_key());
     m.clear();
-    assert_eq!(0, m.next_key());
+    assert_eq!(Ok(0), m.next_key());
 }
 
 #[test]
-#[should_panic]
-fn panics_on_end_of_keys() {
+fn next_key_reports_error_at_capacity() {
     let mut m: Map<u32> = Map::with_capacity_none(1);
     m.insert(0, 42);
-    assert_ne!(1, m.next_key());
+    assert_eq!(Err(MapFullError), m.next_key());
 }


### PR DESCRIPTION
## Summary
- change `Map::push` and `Map::next_key` to return `Result` instead of panicking when the map is full
- update map tests and documentation to reflect the new fallible APIs and highlight `MapFullError`
- adjust the README and perf smoke test to avoid stdout usage and demonstrate the new error-based workflow

## Testing
- `cargo +nightly fmt --`
- `cargo fmt --check`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo test --all-features -vv -- --nocapture`
- `cargo clippy -- --no-deps`
- `cargo audit`
