### PR TITLE
#29 test: enable clone tests and pin expected panic messages

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -23,7 +23,6 @@ fn map_can_be_cloned() {
 }
 
 #[test]
-#[ignore]
 #[allow(clippy::redundant_clone)]
 fn empty_clone() {
     let m: Map<u8> = Map::with_capacity_none(16);
@@ -31,7 +30,6 @@ fn empty_clone() {
 }
 
 #[test]
-#[ignore]
 fn larger_map_can_be_cloned() {
     let cap = 16;
     let mut m: Map<u8> = Map::with_capacity_none(cap);
@@ -48,7 +46,6 @@ struct Foo {
 }
 
 #[test]
-#[ignore]
 fn clone_of_wrapper() {
     let mut f: Foo = Foo {
         m: Map::with_capacity_none(16),

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -187,7 +187,7 @@ mod tests {
 
     /// Out-of-bounds insert must panic in debug builds.
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "over the boundary")]
     #[cfg(debug_assertions)]
     fn insert_out_of_boundary() {
         let mut m: Map<&str> = Map::with_capacity(1);
@@ -196,7 +196,7 @@ mod tests {
 
     /// Out-of-bounds get must panic in debug builds.
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "over the boundary")]
     #[cfg(debug_assertions)]
     fn get_out_of_boundary() {
         let m: Map<&str> = Map::with_capacity(1);
@@ -205,7 +205,7 @@ mod tests {
 
     /// Out-of-bounds remove must panic in debug builds.
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "over the boundary")]
     #[cfg(debug_assertions)]
     fn remove_out_of_boundary() {
         let mut m: Map<&str> = Map::with_capacity(1);

--- a/src/next_key.rs
+++ b/src/next_key.rs
@@ -57,7 +57,7 @@ fn reset_next_key_on_clear() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "No more keys available left")]
 fn panics_on_end_of_keys() {
     let mut m: Map<u32> = Map::with_capacity_none(1);
     m.insert(0, 42);


### PR DESCRIPTION
Closes #29

`src/lib.rs` turns on `clippy::pedantic` next to `#![deny(warnings)]`, so `ignore_without_reason` and `should_panic_without_expect` are errors. Seven test attributes carried no reason and `cargo clippy --no-deps --all-targets` failed with seven errors, which is what a contributor following the README hits first.

The three `#[ignore]` markers in `src/clone.rs` were added in April 2023, when cloning a map that had not been initialized panicked in debug mode. That condition is gone: all three tests pass today, so they are switched back on rather than given a reason to stay disabled.

The four `#[should_panic]` attributes now pin the message. That is more than a lint fix: the three boundary tests in `src/ctors.rs` used to pass on any panic, so they would have stayed green if the boundary check were dropped and something unrelated failed instead.

## Validation

* `cargo test` — 95 passed, 0 ignored, up from 92 passed and 3 ignored
* `cargo fmt --check`
* `cargo clippy --no-deps --all-targets` — clean
* `cargo doc --no-deps`
