### PR TITLE
#28 chore: move intmap to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["memory", "map"]
 categories = ["data-structures", "memory-management"]
 
 [dependencies]
-intmap = "3.1.0"
 serde = { version = "1.0.185", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1.3.3"
+intmap = "3.1.0"
 paste = "1.0"
 criterion = { version = "0.8", features = ["html_reports"] }
 


### PR DESCRIPTION
Closes #28

`intmap` sits in `[dependencies]` but the library never uses it. `grep -rn intmap src/` returns nothing; the only two references are `benches/compare_with_intmap.rs` and `tests/benchmark.rs`. Every downstream user therefore compiles and links a crate that `emap` does not need, and the published metadata advertises a dependency the public API never touches.

The declaration moves to `[dev-dependencies]` with the same version requirement. `Cargo.lock` is unchanged, since the crate is still resolved for the development graph.

## Validation

* `cargo test --all-features`
* `cargo bench --no-run` — all four benchmark binaries still build
* `cargo fmt --check`
* `cargo clippy --no-deps`
* `cargo doc --no-deps`

`cargo clippy --no-deps --all-targets` still reports the seven pre-existing bare `#[ignore]` and `#[should_panic]` attributes. They are unrelated to this branch and are handled separately.
