### PR TITLE
#27 fix: iterate maps whose values are not clonable

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -4,7 +4,7 @@
 use crate::{IntoIter, Iter, IterMut, Map};
 use std::marker::PhantomData;
 
-impl<'a, V: Clone + 'a> Iterator for Iter<'a, V> {
+impl<'a, V> Iterator for Iter<'a, V> {
     type Item = (usize, &'a V);
 
     /// This is an implementation of the `next` function that returns the next item in an iterator if it
@@ -28,7 +28,7 @@ impl<'a, V: Clone + 'a> Iterator for Iter<'a, V> {
     }
 }
 
-impl<'a, V: Clone + 'a> Iterator for IterMut<'a, V> {
+impl<'a, V> Iterator for IterMut<'a, V> {
     type Item = (usize, &'a mut V);
 
     #[inline]
@@ -74,14 +74,20 @@ impl<'a, V: Clone> IntoIterator for &'a Map<V> {
     }
 }
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Make an iterator over all items.
+    ///
+    /// The `IntoIterator` implementation for `&Map<V>` yields owned values and
+    /// therefore requires `V: Clone`, while this method borrows them and works
+    /// for any `V`. The two cannot share an item type until that implementation
+    /// is changed, so the `iter_without_into_iter` lint is muted here.
     ///
     /// # Panics
     ///
     /// It may panic in debug mode, if the [`Map`] is not initialized.
     #[inline]
     #[must_use]
+    #[allow(clippy::iter_without_into_iter)]
     pub const fn iter(&self) -> Iter<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't iter() non-initialized Map");
@@ -212,4 +218,33 @@ fn iterate_and_mutate() {
         sum += v;
     }
     assert_eq!(115, sum);
+}
+
+#[cfg(test)]
+struct NoClone {
+    id: usize,
+}
+
+#[test]
+fn iterates_values_that_are_not_clonable() {
+    let mut m: Map<NoClone> = Map::with_capacity_none(4);
+    m.insert(0, NoClone { id: 1 });
+    m.insert(1, NoClone { id: 3 });
+    let mut sum = 0;
+    for (k, v) in m.iter() {
+        sum += k + v.id;
+    }
+    assert_eq!(5, sum);
+}
+
+#[test]
+fn mutates_values_that_are_not_clonable() {
+    let mut m: Map<NoClone> = Map::with_capacity_none(4);
+    m.insert(0, NoClone { id: 1 });
+    m.insert(1, NoClone { id: 3 });
+    for (k, v) in m.iter_mut() {
+        v.id += k;
+    }
+    assert_eq!(1, m.get(0).unwrap().id);
+    assert_eq!(4, m.get(1).unwrap().id);
 }


### PR DESCRIPTION
Closes #27

`Iter` and `IterMut` yield `&V` and `&mut V` and clone nothing, yet both `Iterator` implementations were bounded by `V: Clone`, and `Map::iter` and `Map::iter_mut` lived in an `impl<V: Clone> Map<V>` block. The result was that a map of values that deliberately do not implement `Clone` could not be walked over at all:

```text
error[E0599]: the method `iter` exists for struct `Map<NoClone>`, but its trait bounds were not satisfied
        `NoClone: Clone`
```

A fixed-capacity map is a natural home for values that own resources, so the bound cut off a whole class of legitimate use.

The bound is dropped from the two `Iterator` implementations and the accessor block. `IntoIter` still yields owned values and keeps `V: Clone`, so nothing that compiles today stops compiling.

Because `iter` is now available for every `V` while `IntoIterator for &Map<V>` still yields owned values, `clippy::iter_without_into_iter` fires on the mismatch. Aligning the two would change what `for (k, v) in &map` yields, which is a public API decision rather than a bug fix, so the lint is muted at the single call site with the reason recorded in the doc comment. That API question belongs in its own ticket.

## Validation

* `cargo test --all-features` — 94 passed, including two new tests that iterate and mutate a map of non-clonable values
* `cargo fmt --check`
* `cargo clippy --no-deps`
* `cargo doc --no-deps`

No runtime code changed, only trait bounds and tests, so benchmark results are unaffected.
