### PR TITLE
#25 fix: size deserialized capacity by the highest key

### DIFF
--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 use crate::Map;
-use serde::de::{MapAccess, Visitor};
+use crate::node::{Node, NodeId};
+use serde::de::{Error as DeError, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
+use std::alloc::Layout;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
+
+/// Upper bound for the space reserved from an untrusted size hint.
+const MAX_PREALLOCATED_ENTRIES: usize = 1024;
+
+/// Entries read from the wire, together with the capacity they demand.
+type Entries<V> = (Vec<(usize, V)>, usize);
 
 impl<V: Clone + Serialize> Serialize for Map<V> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -37,16 +44,47 @@ impl<'de, V: Clone + Deserialize<'de>> Visitor<'de> for Vi<V> {
     where
         M: MapAccess<'de>,
     {
-        let mut map: HashMap<usize, V> = HashMap::new();
-        while let Some((key, value)) = access.next_entry()? {
-            map.insert(key, value);
-        }
-        let mut m: Self::Value = Map::with_capacity_none(map.len());
-        for (k, v) in &map {
-            m.insert(*k, v.clone());
+        let (entries, cap) = collect_entries::<M, V>(&mut access)?;
+        let mut m: Self::Value = Map::with_capacity_none(cap);
+        for (key, value) in entries {
+            m.insert(key, value);
         }
         Ok(m)
     }
+}
+
+/// Read every entry and report the capacity the highest key demands.
+///
+/// # Errors
+///
+/// Fails on the reserved `usize::MAX` key and on a capacity that no `Layout`
+/// can describe.
+fn collect_entries<'de, M, V>(access: &mut M) -> Result<Entries<V>, M::Error>
+where
+    M: MapAccess<'de>,
+    V: Deserialize<'de>,
+{
+    let mut entries: Vec<(usize, V)> = Vec::new();
+    if let Some(hint) = access.size_hint() {
+        entries.reserve(hint.min(MAX_PREALLOCATED_ENTRIES));
+    }
+    let mut max_key: Option<usize> = None;
+    while let Some((key, value)) = access.next_entry::<usize, V>()? {
+        if key == NodeId::UNDEF {
+            return Err(DeError::custom(
+                "the key usize::MAX is reserved and cannot be used",
+            ));
+        }
+        max_key = Some(max_key.map_or(key, |seen: usize| seen.max(key)));
+        entries.push((key, value));
+    }
+    let cap = max_key.map_or(0, |key| key + 1);
+    if Layout::array::<Node<V>>(cap).is_err() {
+        return Err(DeError::custom(
+            "the highest key requires a capacity beyond addressable memory",
+        ));
+    }
+    Ok((entries, cap))
 }
 
 impl<'de, V: Clone + Deserialize<'de>> Deserialize<'de> for Map<V> {
@@ -80,4 +118,46 @@ fn serde_big_map() {
     let bytes: Vec<u8> = serialize(&before).unwrap();
     let after: Map<u8> = deserialize(&bytes).unwrap();
     assert_eq!(2, after.capacity());
+}
+
+/// A map whose highest key exceeds the number of entries must survive a round
+/// trip, since the capacity has to follow the key and not the entry count.
+#[test]
+fn keeps_sparse_keys_over_a_round_trip() {
+    let mut before: Map<u8> = Map::with_capacity_none(32);
+    before.insert(0, 1);
+    before.insert(31, 2);
+    let bytes: Vec<u8> = serialize(&before).unwrap();
+    let after: Map<u8> = deserialize(&bytes).unwrap();
+    assert_eq!(32, after.capacity());
+    assert_eq!(2, after.len());
+    assert_eq!(Some(&1), after.get(0));
+    assert_eq!(Some(&2), after.get(31));
+}
+
+/// The reserved sentinel key must be reported as an error instead of being
+/// inserted.
+#[test]
+fn rejects_the_reserved_key() {
+    use serde::de::IntoDeserializer;
+    use serde::de::value::{Error as ValueError, MapDeserializer};
+    let entry = std::iter::once((NodeId::UNDEF.into_deserializer(), 0u8.into_deserializer()));
+    let deserializer = MapDeserializer::<_, ValueError>::new(entry);
+    let err = Map::<u8>::deserialize(deserializer).unwrap_err();
+    assert!(err.to_string().contains("is reserved and cannot be used"));
+}
+
+/// A key that demands more memory than the address space can hold must be
+/// reported as an error instead of aborting on allocation failure.
+#[test]
+fn rejects_a_key_beyond_addressable_memory() {
+    use serde::de::IntoDeserializer;
+    use serde::de::value::{Error as ValueError, MapDeserializer};
+    let entry = std::iter::once((
+        (NodeId::UNDEF - 1).into_deserializer(),
+        0u8.into_deserializer(),
+    ));
+    let deserializer = MapDeserializer::<_, ValueError>::new(entry);
+    let err = Map::<u8>::deserialize(deserializer).unwrap_err();
+    assert!(err.to_string().contains("beyond addressable memory"));
 }


### PR DESCRIPTION
Closes #25

The `Deserialize` implementation sized the target map with `Map::with_capacity_none(map.len())` and then inserted every entry at its original key. For a sparse map the highest key is larger than the entry count, so the insert crossed the boundary and panicked:

```rust
let mut before: Map<u8> = Map::with_capacity_none(32);
before.insert(0, 1);
before.insert(31, 2);
let bytes: Vec<u8> = bincode::serialize(&before).unwrap();
let after: Map<u8> = bincode::deserialize(&bytes).unwrap();
```

```text
thread panicked at src/map.rs:264:9:
The key 31 is over the boundary 2
```

Capacity is now derived from the highest key seen, so every entry lands where it was written. Two related gaps in the same code path are closed as well: `usize::MAX` is the internal sentinel and is now refused instead of silently corrupting the free list, and a capacity that no `Layout` can describe is reported as a deserialization error rather than reaching the allocator.

The intermediate `HashMap` is replaced by a `Vec`, so deserialization gets cheaper rather than more expensive: it no longer hashes every key and no longer clones every value. Space reserved from the incoming size hint is capped, so an untrusted hint cannot ask for an arbitrary allocation up front.

## Validation

* `cargo test --all-features` — 97 passed, three of them new: the sparse round trip, the reserved key and the oversized capacity
* `cargo fmt --check`
* `cargo clippy --no-deps --all-features`
* `cargo doc --no-deps --all-features`

The `bincode` development dependency stays at 1.3.3, the version deliberately restored in #181.
